### PR TITLE
Remove Python version from Set Up Python step name

### DIFF
--- a/.github/workflows/pythonapp-workflow.yml
+++ b/.github/workflows/pythonapp-workflow.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
             cache: 'pip'


### PR DESCRIPTION
Small change to remove 3.10 from the name of the Python setup step in pythonapp-workflow.yml (`actions/setup-python@v5` will use the Python version specified in [`.python-version`](https://github.com/reichlab/reichlab-python-template/blob/main/.python-version)).