### PR TITLE
Fix pip install when setting up code checks workflow

### DIFF
--- a/.github/workflows/pythonapp-workflow.yml
+++ b/.github/workflows/pythonapp-workflow.yml
@@ -12,7 +12,7 @@ jobs:
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/requirements-dev.txt -e .
+          pip install -r requirements/requirements-dev.txt && pip install -e .
       - name: lint
         run: |
            ruff check .


### PR DESCRIPTION
This typo causes terrible things to happen on projects with dependencies install via github 😱 