### PR TITLE
Update uv sync command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ To add or remove a project dependency:
     #
     # alternately, you can use uv to install the dependencies: it is faster and has a
     # a handy sync option that will cleanup unused dependencies
-    uv pip sync requirements/requirements-dev.txt
+    uv pip sync requirements/requirements-dev.txt && python -m pip install -e .
     ```
 
 ## Opinionated notes on Python tooling


### PR DESCRIPTION
As far as I can tell, running `uv sync` by itself removes the install of the package itself because it's not listed in the `requirements-dev.txt`.  This PR tacks ` && python -m pip install -e .` on to the end of the `uv sync` command so that when new dev requirements are added to the project you can easily copy/paste a command that will sync the requirements and still end up with the package itself installed.